### PR TITLE
detect Fedora version correctly

### DIFF
--- a/terra.repo
+++ b/terra.repo
@@ -1,11 +1,11 @@
 [terra]
-name=Terra $releasever
-baseurl=https://repos.fyralabs.com/terra$releasever
+name=Terra $(rpm -E %fedora)
+baseurl=https://repos.fyralabs.com/terra$(rpm -E %fedora)
 type=rpm
 skip_if_unavailable=True
 gpgcheck=1
 repo_gpgcheck=1
-gpgkey=https://repos.fyralabs.com/terra$releasever/key.asc
+gpgkey=https://repos.fyralabs.com/terra$(rpm -E %fedora)/key.asc
 enabled=1
 enabled_metadata=1
 metadata_expire=4h


### PR DESCRIPTION
this is the code used on rpmfusion too. $releasever is not a set variable by default.